### PR TITLE
v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - **Possible break change** PHP Strict types.
-- New `DatabaseDriver::isForeignKeyEnabled()` method (`bool`) added for compatibility (implemented on sqlite, return false by other drivers).
+- New `DatabaseDriver::isForeignKeyEnabled()` method (`bool`) added for compatibility (implemented on sqlite, returns true by other drivers as there is now way to disable FK).
 
 ## [v0.5] - 2020-10-08
 

--- a/lib/Driver/Mysql/MysqlDriver.php
+++ b/lib/Driver/Mysql/MysqlDriver.php
@@ -137,14 +137,14 @@ class MysqlDriver extends ServerDriver
 
     /**
      * Get whether foreign keys are enabled or not
-     * For compatibility with Sqlite, not implemented in that driver, return false 
-
+     * For compatibility with Sqlite, not implemented in that driver (allways enabled), return true
+     * 
      * @access public
      * @return bool     true if foreign keys are enabled, otherwise false
      */
     public function isForeignKeyEnabled(): bool
     {
-        return false;
+        return true;
     }
     
     /**

--- a/lib/Driver/Postgres/PostgresDriver.php
+++ b/lib/Driver/Postgres/PostgresDriver.php
@@ -157,14 +157,14 @@ class PostgresDriver extends ServerDriver
     
     /**
      * Get whether foreign keys are enabled or not
-     * For compatibility with Sqlite, not implemented in that driver, return false 
+     * For compatibility with Sqlite, not implemented in that driver (allways enabled), return true 
 
      * @access public
      * @return bool     true if foreign keys are enabled, otherwise false
      */
     public function isForeignKeyEnabled(): bool
     {
-        return false;
+        return true;
     }
 
     /**

--- a/tests/mysql/MysqlDriverTest.php
+++ b/tests/mysql/MysqlDriverTest.php
@@ -32,6 +32,12 @@ class MysqlDriverTest extends TestCase
         new Kristuff\Patabase\Driver\Mysql\MysqlDriver(array());
     }
 
+
+    public function testIsFkEnabled()
+    {
+        $this->assertTrue(self::$srv->getDriver()->isForeignKeyEnabled());
+    }
+
     public function testEscape()
     {
         $this->assertEquals('`a`', self::$srv->getDriver()->escape('a'));

--- a/tests/pgsql/PgsqlDriverTest.php
+++ b/tests/pgsql/PgsqlDriverTest.php
@@ -32,6 +32,11 @@ class PgsqlDriverTest extends TestCase
         new Kristuff\Patabase\Driver\Mysql\MysqlDriver(array());
     }
 
+    public function testIsFkEnabled()
+    {
+        $this->assertTrue(self::$srv->getDriver()->isForeignKeyEnabled());
+    }
+
     public function testEscape()
     {
         $this->assertEquals('"a"', self::$srv->getDriver()->escape('a'));

--- a/tests/sqlite/SqliteDriverTest.php
+++ b/tests/sqlite/SqliteDriverTest.php
@@ -26,6 +26,7 @@ class SqliteDriverTest extends TestCase
         new Kristuff\Patabase\Driver\Sqlite\SqliteDriver(array());
     }
 
+  
     public function testEscape()
     {
         $this->assertEquals('"a"', self::$db->getDriver()->escape('a'));


### PR DESCRIPTION
- **Possible break change** PHP Strict types.
- New `DatabaseDriver::isForeignKeyEnabled()` method (`bool`) added for compatibility (implemented on sqlite, returns true by other drivers as there is now way to disable FK).
